### PR TITLE
Don't ask for input and don't initialize Terraform backends

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -30,7 +30,8 @@ jobs:
         uses: hashicorp/setup-terraform@v2
       - name: Terraform init
         working-directory: ${{ matrix.terraform-environments }}
-        run: terraform init
+        # Don't initialize the backend because we may not have any remote backend configuration available
+        run: terraform init -backend=false -input=false
       - name: Terraform validate
         working-directory: ${{ matrix.terraform-environments }}
         run: terraform validate


### PR DESCRIPTION
When running the Terraform validation jobs, don't ask for any input and don't try to initialize the backend because we might not have the necessary configuration data to initialize one (i.e. when we try to initialize a remote backend).