### PR TITLE
Remove unneeded Kubeval config

### DIFF
--- a/config/lint/super-linter.env
+++ b/config/lint/super-linter.env
@@ -3,7 +3,6 @@ ERROR_ON_MISSING_EXEC_BIT=true
 IGNORE_GITIGNORED_FILES=true
 JAVA_FILE_NAME=google_checks.xml
 KUBERNETES_KUBECONFORM_OPTIONS=--strict --ignore-missing-schemas
-KUBERNETES_KUBEVAL_OPTIONS=--strict --ignore-missing-schemas --schema-location https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/
 LINTER_RULES_PATH=config/lint
 SUPPRESS_POSSUM=true
 VALIDATE_ALL_CODEBASE=true


### PR DESCRIPTION
We updated super-linter to v5 in #98, and it doesn't bundle Kubeval anymore. We can remove the related configuration.