### PR TITLE
Automate dependabot PRs

### DIFF
--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -8,6 +8,7 @@ on:  # yamllint disable-line rule:truthy
       - synchronize
 
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -26,6 +26,6 @@ jobs:
       - name: Approve the PR
         run: gh pr review --approve "${PR_URL}"
       - name: Enable auto-merge for patch updates PR
-        if: {{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: gh pr merge --auto --squash --delete-branch "${PR_URL}"
 ...

--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -26,6 +26,6 @@ jobs:
       - name: Approve the PR
         run: gh pr review --approve "${PR_URL}"
       - name: Enable auto-merge for patch updates PR
-        if: {{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        if: {{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
         run: gh pr merge --auto --squash --delete-branch "${PR_URL}"
 ...

--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -26,6 +26,6 @@ jobs:
       - name: Approve the PR
         run: gh pr review --approve "${PR_URL}"
       - name: Enable auto-merge for patch updates PR
-        if: {{steps.metadata.outputs.update-type == 'version-update:semver-patch'}}
+        if: {{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
         run: gh pr merge --auto --squash --delete-branch "${PR_URL}"
 ...

--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -1,0 +1,31 @@
+---
+name: Dependabot automation
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - synchronize
+
+permissions:
+  pull-requests: write
+
+jobs:
+  dependabot:
+    env:
+      PR_URL: ${{github.event.pull_request.html_url}}
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Approve the PR
+        run: gh pr review --approve "${PR_URL}"
+      - name: Enable auto-merge for patch updates PR
+        if: {{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: gh pr merge --auto --squash --delete-branch "${PR_URL}"
+...


### PR DESCRIPTION
This PR adds a workflow to automatically approve PRs that Dependabot opens and to enable auto-merge for `patch` updates.