### PR TITLE
Add source MQTT topic name as a header to Cloud Pub/Sub messages

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -75,6 +75,13 @@ By setting it a wildcard MQTT subscription, you can forward MQTT messages sent t
 that match with the wildcard subscription to the Cloud Pub/Sub topic that you configured with the
 `<destination-cloud-pubsub-topic>` option, as described above.
 
+### Source MQTT topic
+
+The `<source-mqtt-topic>` name is added as a header to Cloud Pub/Sub messages.
+The key of this header is defined in the
+`com.google.cloud.solutions.routesMqttToCloudPubSubRoute.SOURCE_MQTT_TOPIC_HEADER_NAME`
+constant.
+
 ## Other configuration options
 
 Part of the MQTT <-> Cloud Pub/Sub Connector uses Apache Camel, but not all Apache Camel

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -98,7 +98,7 @@ if ! is_ci; then
     _DOCKER_INTERACTIVE_TTY_OPTION="-it"
   fi
 
-  LINTER_CONTAINER_IMAGE="ghcr.io/github/super-linter:${LINTER_CONTAINER_IMAGE_VERSION:-"latest"}"
+  LINTER_CONTAINER_IMAGE="ghcr.io/super-linter/super-linter:${LINTER_CONTAINER_IMAGE_VERSION:-"latest"}"
 
   if [ "${UPDATE_CONTAINER_IMAGE:-}" = "true" ]; then
     docker pull "${LINTER_CONTAINER_IMAGE}"


### PR DESCRIPTION
In this PR, we map the source MQTT topic name to a header in the Cloud Pub/Sub messages we forward. This is especially useful when this connector maps a wildcard MQTT subscription to a single Cloud Pub/Sub topic.

Close #201

As a minor change, we also update the super-linter container image ID to `super-linter/super-linter` because it moved to a dedicated organization.

/cc @r-harrison: can you kindly check if this is what you requested? Thanks!