### PR TITLE
Automate dependabot action

### DIFF
--- a/.github/workflows/dependabot-automation.yaml
+++ b/.github/workflows/dependabot-automation.yaml
@@ -40,6 +40,7 @@ jobs:
           || steps.metadata.outputs.dependency-names == 'hashicorp/google'
           || steps.metadata.outputs.dependency-names == 'hashicorp/terraform'
           || steps.metadata.outputs.dependency-names == 'numpy'
+          || steps.metadata.outputs.dependency-names == 'super-linter/super-linter'
           || steps.metadata.outputs.dependency-names == 'terraform-google-modules/cloud-router/google'
           || steps.metadata.outputs.dependency-names == 'terraform-google-modules/cloud-storage/google'
           || steps.metadata.outputs.dependency-names == 'terraform-google-modules/kubernetes-engine/google'


### PR DESCRIPTION
Add `super-linter/super-linter` to the set of automatically managed dependencies.