### PR TITLE
fix: get super-linter version from workflow

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -98,7 +98,9 @@ if ! is_ci; then
     _DOCKER_INTERACTIVE_TTY_OPTION="-it"
   fi
 
-  LINTER_CONTAINER_IMAGE="ghcr.io/super-linter/super-linter:${LINTER_CONTAINER_IMAGE_VERSION:-"latest"}"
+  LINT_CI_JOB_PATH=".github/workflows/lint.yaml"
+  DEFAULT_LINTER_CONTAINER_IMAGE_VERSION="$(grep <"${LINT_CI_JOB_PATH}" "super-linter/super-linter" | awk -F '@' '{print $2}' | head --lines=1)"
+  LINTER_CONTAINER_IMAGE="ghcr.io/super-linter/super-linter:${LINTER_CONTAINER_IMAGE_VERSION:-${DEFAULT_LINTER_CONTAINER_IMAGE_VERSION}}"
 
   if [ "${UPDATE_CONTAINER_IMAGE:-}" = "true" ]; then
     docker pull "${LINTER_CONTAINER_IMAGE}"


### PR DESCRIPTION
Get the Super-linter version from the GitHub Actions lint workflow, instead of defaulting to "latest". This makes local builds reproducible because the build.sh script runs the same Super-linter version as the CI workflow, unless the user explicitly overrides the Super-linter version.